### PR TITLE
feat: add SQLite persistence for activities and participants

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,11 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
+from typing import Dict, Any
+
+# Database file
+DB_PATH = os.path.join(Path(__file__).parent, "data.sqlite")
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +24,122 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("""
+    CREATE TABLE IF NOT EXISTS activities (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE NOT NULL,
+        description TEXT,
+        schedule TEXT,
+        max_participants INTEGER
+    )
+    """)
+    cur.execute("""
+    CREATE TABLE IF NOT EXISTS participants (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        activity_name TEXT NOT NULL,
+        email TEXT NOT NULL,
+        UNIQUE(activity_name, email)
+    )
+    """)
+    conn.commit()
+
+    # Seed with initial data if activities table is empty
+    cur.execute("SELECT count(*) as c FROM activities")
+    row = cur.fetchone()
+    if row and row[0] == 0:
+        seed_activities = {
+            "Chess Club": {
+                "description": "Learn strategies and compete in chess tournaments",
+                "schedule": "Fridays, 3:30 PM - 5:00 PM",
+                "max_participants": 12,
+                "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+            },
+            "Programming Class": {
+                "description": "Learn programming fundamentals and build software projects",
+                "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+                "max_participants": 20,
+                "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+            },
+            "Gym Class": {
+                "description": "Physical education and sports activities",
+                "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+                "max_participants": 30,
+                "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+            },
+            "Soccer Team": {
+                "description": "Join the school soccer team and compete in matches",
+                "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+                "max_participants": 22,
+                "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+            },
+            "Basketball Team": {
+                "description": "Practice and play basketball with the school team",
+                "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+                "max_participants": 15,
+                "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+            },
+            "Art Club": {
+                "description": "Explore your creativity through painting and drawing",
+                "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+                "max_participants": 15,
+                "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+            },
+            "Drama Club": {
+                "description": "Act, direct, and produce plays and performances",
+                "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+                "max_participants": 20,
+                "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+            },
+            "Math Club": {
+                "description": "Solve challenging problems and participate in math competitions",
+                "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+                "max_participants": 10,
+                "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+            },
+            "Debate Team": {
+                "description": "Develop public speaking and argumentation skills",
+                "schedule": "Fridays, 4:00 PM - 5:30 PM",
+                "max_participants": 12,
+                "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+            }
+        }
+
+        for name, data in seed_activities.items():
+            cur.execute(
+                "INSERT INTO activities (name, description, schedule, max_participants) VALUES (?, ?, ?, ?)",
+                (name, data["description"], data["schedule"], data["max_participants"])
+            )
+            for p in data.get("participants", []):
+                cur.execute(
+                    "INSERT OR IGNORE INTO participants (activity_name, email) VALUES (?, ?)",
+                    (name, p)
+                )
+        conn.commit()
+
+    conn.close()
+
+
+def activity_row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    return {
+        "name": row["name"],
+        "description": row["description"],
+        "schedule": row["schedule"],
+        "max_participants": row["max_participants"],
+        "participants": []
     }
-}
+
+
+# In-memory activity placeholder (no longer used; persisted to SQLite)
+activities = None
 
 
 @app.get("/")
@@ -85,48 +149,66 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM activities")
+    rows = cur.fetchall()
+    result = {}
+    for r in rows:
+        activity = activity_row_to_dict(r)
+        cur.execute("SELECT email FROM participants WHERE activity_name = ?", (r["name"],))
+        parts = [row["email"] for row in cur.fetchall()]
+        activity["participants"] = parts
+        result[r["name"]] = activity
+    conn.close()
+    return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM activities WHERE name = ?", (activity_name,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    # Check if already signed up
+    cur.execute("SELECT 1 FROM participants WHERE activity_name = ? AND email = ?", (activity_name, email))
+    if cur.fetchone():
+        conn.close()
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
     # Add student
-    activity["participants"].append(email)
+    cur.execute("INSERT INTO participants (activity_name, email) VALUES (?, ?)", (activity_name, email))
+    conn.commit()
+    conn.close()
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM activities WHERE name = ?", (activity_name,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    cur.execute("SELECT 1 FROM participants WHERE activity_name = ? AND email = ?", (activity_name, email))
+    if not cur.fetchone():
+        conn.close()
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
+    cur.execute("DELETE FROM participants WHERE activity_name = ? AND email = ?", (activity_name, email))
+    conn.commit()
+    conn.close()
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+# Initialize DB on import
+init_db()


### PR DESCRIPTION
This PR introduces a small SQLite-based persistence layer using Python's builtin sqlite3 module.

Changes:
- Add DB initialization (`data.sqlite`) and migration to create `activities` and `participants` tables.
- Seed initial activities and participants on first run.
- Update endpoints in `src/app.py` to read/write activities and participants from the database.

Notes:
- No external dependencies were added; this uses the stdlib `sqlite3` module.
- Authentication and RBAC are not included in this PR; they are next items.
- I ran a quick smoke test by importing `src.app` and calling `get_activities()` which returned 9 seeded activities.

Next steps: add tests, move DB path into config, and add migrations/tests as follow-ups.